### PR TITLE
Fix temp path function within tests

### DIFF
--- a/src/test/hawk/test_helper.clj
+++ b/src/test/hawk/test_helper.clj
@@ -6,7 +6,10 @@
 (def timeout 30000)
 
 (defn new-temp-path []
-  (str (System/getProperty "java.io.tmpdir") (gensym "hawk") "/"))
+  (.getPath
+   (io/file
+    (System/getProperty "java.io.tmpdir")
+    (str (gensym "hawk")))))
 
 (defn create-file [file]
   (doto file .createNewFile))


### PR DESCRIPTION
Running the test suite on Linux caused the tests to fail because of an OS specific file separator issue.
