### PR TITLE
Ensure that the watcher thread is a daemon thread

### DIFF
--- a/src/main/clojure/hawk/core.clj
+++ b/src/main/clojure/hawk/core.clj
@@ -88,6 +88,7 @@
                      (empty?
                        (mapv handler* (watcher/take! watcher)))
                      (recur))))
+               (.setDaemon true)
                .start)
      :watcher watcher}))
 


### PR DESCRIPTION
Calling `.setDaemon` with `true` on the watcher thread allows the JVM to exit even if the thread is still active, so it doesn't have to be explicitly shut down on process exit.